### PR TITLE
Fix single circle app

### DIFF
--- a/apps/single_circle.py
+++ b/apps/single_circle.py
@@ -95,6 +95,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              102,    # seed
+             None,
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_circle/final.png')


### PR DESCRIPTION
Hi @BachiLi,

again an awesome project! There's a small typo in the single circle app that causes a crash (`background_image` argument is missing on the last `render` call).