### PR TITLE
Fix missing background_image argument

### DIFF
--- a/apps/single_curve_outline.py
+++ b/apps/single_curve_outline.py
@@ -34,6 +34,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_curve_outline/target.png', gamma=2.2)
@@ -65,6 +66,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_curve_outline/init.png', gamma=2.2)
 
@@ -86,6 +88,7 @@ for t in range(200):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_curve_outline/iter_{}.png'.format(t), gamma=2.2)
@@ -121,6 +124,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              202,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_curve_outline/final.png')

--- a/apps/single_curve_sdf.py
+++ b/apps/single_curve_sdf.py
@@ -34,6 +34,7 @@ img = render(256, # width
              1,   # num_samples_x
              1,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 img /= 256.0
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
@@ -63,6 +64,7 @@ img = render(256, # width
              1,   # num_samples_x
              1,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 img /= 256.0
 pydiffvg.imwrite(img.cpu(), 'results/single_curve_sdf/init.png', gamma=1.0)
@@ -84,6 +86,7 @@ for t in range(100):
                  1,     # num_samples_x
                  1,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     img /= 256.0
     # Save the intermediate render.
@@ -113,6 +116,7 @@ img = render(256,   # width
              1,     # num_samples_x
              1,     # num_samples_y
              102,    # seed
+             None, # background_image
              *scene_args)
 img /= 256.0
 # Save the images and differences.

--- a/apps/single_curve_sdf_trans.py
+++ b/apps/single_curve_sdf_trans.py
@@ -40,6 +40,7 @@ img = render(256, # width
              1,   # num_samples_x
              1,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 
 path.points[:, 1] += 1e-3
@@ -51,6 +52,7 @@ img2 = render(256, # width
               1,   # num_samples_x
               1,   # num_samples_y
               0,   # seed
+              None, # background_image
               *scene_args)
 
 # diff = img2 - img
@@ -70,6 +72,7 @@ img = render_grad(torch.ones(256, 256, 1), # grad_img
                   1,   # num_samples_x
                   1,   # num_samples_y
                   0,   # seed
+                  None, # background_image
                   *scene_args)
 img = img[:, :, 0]
 import matplotlib.pyplot as plt
@@ -109,6 +112,7 @@ plt.show()
 #              1,   # num_samples_x
 #              1,   # num_samples_y
 #              1,   # seed
+#              None, # background_image
 #              *scene_args)
 # img /= 256.0
 # pydiffvg.imwrite(img.cpu(), 'results/single_curve_sdf/init.png', gamma=1.0)
@@ -130,6 +134,7 @@ plt.show()
 #                  1,     # num_samples_x
 #                  1,     # num_samples_y
 #                  t+1,   # seed
+#                  None, # background_image
 #                  *scene_args)
 #     img /= 256.0
 #     # Save the intermediate render.
@@ -160,6 +165,7 @@ plt.show()
 #              1,     # num_samples_x
 #              1,     # num_samples_y
 #              102,    # seed
+#              None, # background_image
 #              *scene_args)
 # img /= 256.0
 # # Save the images and differences.

--- a/apps/single_ellipse.py
+++ b/apps/single_ellipse.py
@@ -22,6 +22,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_ellipse/target.png', gamma=2.2)
@@ -42,6 +43,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_ellipse/init.png', gamma=2.2)
 
@@ -62,6 +64,7 @@ for t in range(50):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_ellipse/iter_{}.png'.format(t), gamma=2.2)
@@ -94,6 +97,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              52,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_ellipse/final.png')

--- a/apps/single_ellipse_transform.py
+++ b/apps/single_ellipse_transform.py
@@ -24,6 +24,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_ellipse_transform/target.png', gamma=2.2)
@@ -49,6 +50,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_ellipse_transform/init.png', gamma=2.2)
 
@@ -68,6 +70,7 @@ for t in range(150):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_ellipse_transform/iter_{}.png'.format(t), gamma=2.2)
@@ -97,6 +100,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              52,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_ellipse_transform/final.png')

--- a/apps/single_gradient.py
+++ b/apps/single_gradient.py
@@ -27,6 +27,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_gradient/target.png', gamma=2.2)
@@ -54,6 +55,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_gradient/init.png', gamma=2.2)
 
@@ -77,6 +79,7 @@ for t in range(100):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_gradient/iter_{}.png'.format(t), gamma=2.2)
@@ -116,6 +119,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              52,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_gradient/final.png')

--- a/apps/single_open_curve.py
+++ b/apps/single_open_curve.py
@@ -13,7 +13,6 @@ points = torch.tensor([[120.0,  30.0], # base
                        [ 60.0, 218.0]]) # base
 path = pydiffvg.Path(num_control_points = num_control_points,
                      points = points,
-                     thickness = None,
                      is_closed = False,
                      stroke_width = torch.tensor(5.0))
 shapes = [path]
@@ -30,6 +29,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_open_curve/target.png', gamma=2.2)
@@ -54,6 +54,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_open_curve/init.png', gamma=2.2)
 
@@ -74,6 +75,7 @@ for t in range(200):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_open_curve/iter_{}.png'.format(t), gamma=2.2)
@@ -106,6 +108,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              202,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_open_curve/final.png')

--- a/apps/single_open_curve_thickness.py
+++ b/apps/single_open_curve_thickness.py
@@ -32,6 +32,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_open_curve_thickness/target.png', gamma=2.2)
@@ -57,6 +58,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_open_curve_thickness/init.png', gamma=2.2)
 
@@ -77,6 +79,7 @@ for t in range(200):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_open_curve_thickness/iter_{}.png'.format(t), gamma=2.2)
@@ -109,6 +112,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              202,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_open_curve_thickness/final.png')

--- a/apps/single_path.py
+++ b/apps/single_path.py
@@ -20,6 +20,7 @@ img = render(510, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_path/target.png', gamma=2.2)
@@ -40,6 +41,7 @@ img = render(510, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_path/init.png', gamma=2.2)
 
@@ -59,6 +61,7 @@ for t in range(100):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_path/iter_{:02}.png'.format(t), gamma=2.2)
@@ -88,6 +91,7 @@ img = render(510,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              102,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_path/final.png')

--- a/apps/single_path_sdf.py
+++ b/apps/single_path_sdf.py
@@ -21,6 +21,7 @@ img = render(510, # width
              1,   # num_samples_x
              1,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 img = img / 510 # Normalize SDF to [0, 1]
 pydiffvg.imwrite(img.cpu(), 'results/single_path_sdf/target.png', gamma=1.0)
@@ -42,6 +43,7 @@ img = render(510, # width
              1,   # num_samples_x
              1,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 img = img / 510 # Normalize SDF to [0, 1]
 pydiffvg.imwrite(img.cpu(), 'results/single_path_sdf/init.png', gamma=1.0)
@@ -63,6 +65,7 @@ for t in range(100):
                  1,     # num_samples_x
                  1,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     img = img / 510 # Normalize SDF to [0, 1]
     # Save the intermediate render.
@@ -94,6 +97,7 @@ img = render(510,   # width
              1,     # num_samples_x
              1,     # num_samples_y
              102,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_path_sdf/final.png')

--- a/apps/single_polygon.py
+++ b/apps/single_polygon.py
@@ -27,6 +27,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_polygon/target.png', gamma=2.2)
@@ -49,6 +50,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_polygon/init.png', gamma=2.2)
 
@@ -68,6 +70,7 @@ for t in range(100):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_polygon/iter_{}.png'.format(t), gamma=2.2)
@@ -97,6 +100,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              102,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_polygon/final.png')

--- a/apps/single_rect.py
+++ b/apps/single_rect.py
@@ -22,6 +22,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_rect/target.png', gamma=2.2)
@@ -42,6 +43,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_rect/init.png', gamma=2.2)
 
@@ -62,6 +64,7 @@ for t in range(100):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_rect/iter_{}.png'.format(t), gamma=2.2)
@@ -91,6 +94,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              102,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_rect/final.png')

--- a/apps/single_stroke.py
+++ b/apps/single_stroke.py
@@ -30,6 +30,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'results/single_stroke/target.png', gamma=2.2)
@@ -54,6 +55,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 pydiffvg.imwrite(img.cpu(), 'results/single_stroke/init.png', gamma=2.2)
 
@@ -74,6 +76,7 @@ for t in range(200):
                  2,     # num_samples_x
                  2,     # num_samples_y
                  t+1,   # seed
+                 None, # background_image
                  *scene_args)
     # Save the intermediate render.
     pydiffvg.imwrite(img.cpu(), 'results/single_stroke/iter_{}.png'.format(t), gamma=2.2)
@@ -106,6 +109,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              202,    # seed
+             None, # background_image
              *scene_args)
 # Save the images and differences.
 pydiffvg.imwrite(img.cpu(), 'results/single_stroke/final.png')

--- a/apps/svg_parse_test.py
+++ b/apps/svg_parse_test.py
@@ -21,9 +21,9 @@ for x in range(100000):
         print(outmat)
         print(decomp)"""
 
-#infile='../../data/test_data/linear_grad_alpha_aspaths.svg'
-#infile='../../data/note_small.svg'
-infile='linux.svg'
+
+infile='./imgs/note_small.svg'
+
 
 canvas_width, canvas_height, shapes, shape_groups = \
 	pydiffvg.svg_to_scene(infile)
@@ -35,6 +35,7 @@ img = render(canvas_width, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 # The output image is in linear RGB space. Do Gamma correction before saving the image.
 pydiffvg.imwrite(img.cpu(), 'test_old.png', gamma=1.0)
@@ -50,6 +51,7 @@ img = render(scene[0], # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 
 

--- a/apps/test_eval_positions.py
+++ b/apps/test_eval_positions.py
@@ -24,6 +24,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              0,   # seed
+             None, # background_image
              *scene_args)
 img = img / 256 # Normalize SDF to [0, 1]
 pydiffvg.imwrite(img.cpu(), 'results/test_eval_positions/target.png')
@@ -45,6 +46,7 @@ img = render(256, # width
              2,   # num_samples_x
              2,   # num_samples_y
              1,   # seed
+             None, # background_image
              *scene_args)
 img = img / 256 # Normalize SDF to [0, 1]
 pydiffvg.imwrite(img.cpu(), 'results/test_eval_positions/init.png')
@@ -60,7 +62,7 @@ for t in range(200):
     circle.center = center_n * 256
     circle_group.fill_color = color
     # Evaluate 1000 positions
-    eval_positions = torch.rand(1000, 2) * 256
+    eval_positions = torch.rand(1000, 2).to(img.device) * 256
     # for grid_sample()
     grid_eval_positions = (eval_positions / 256.0) * 2.0 - 1.0
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
@@ -72,6 +74,7 @@ for t in range(200):
                      0,     # num_samples_x
                      0,     # num_samples_y
                      t+1,   # seed
+                     None, # background_image
                      *scene_args)
     samples = samples / 256 # Normalize SDF to [0, 1]
     target_sampled = torch.nn.functional.grid_sample(\
@@ -103,6 +106,7 @@ img = render(256,   # width
              2,     # num_samples_x
              2,     # num_samples_y
              102,    # seed
+             None, # background_image
              *scene_args)
 img = img / 256 # Normalize SDF to [0, 1]
 # Save the images and differences.

--- a/pydiffvg/optimize_svg.py
+++ b/pydiffvg/optimize_svg.py
@@ -1028,6 +1028,7 @@ class OptimizableSvg:
                      2,  # num_samples_x
                      2,  # num_samples_y
                      seed,  # seed
+                     None, # background_image
                      *scene_args)
         return img
 

--- a/pydiffvg_tensorflow/render_tensorflow.py
+++ b/pydiffvg_tensorflow/render_tensorflow.py
@@ -1,3 +1,4 @@
+import os
 import tensorflow as tf
 import diffvg
 import pydiffvg_tensorflow as pydiffvg
@@ -457,7 +458,7 @@ def render(*x):
         The main TensorFlow interface of C++ diffvg.
     """
     assert(tf.executing_eagerly())
-    if pydiffvg.get_use_gpu() and os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] != 'true':
+    if pydiffvg.get_use_gpu() and os.environ.get('TF_FORCE_GPU_ALLOW_GROWTH') != 'true':
         print('******************** WARNING ********************')
         print('Tensorflow by default allocates all GPU memory,')
         print('causing huge amount of page faults when rendering.')


### PR DESCRIPTION
This PR fixes missing `background_image` argument of the `render` function in many of the example scripts (along with a few other minor error).