### PR TITLE
Added null pointers for background image and eval positions

### DIFF
--- a/pydiffvg_tensorflow/render_tensorflow.py
+++ b/pydiffvg_tensorflow/render_tensorflow.py
@@ -423,6 +423,7 @@ def forward(width,
 
         start = time.time()
         diffvg.render(scene,
+                      diffvg.float_ptr(0), # background image
                       diffvg.float_ptr(pydiffvg.data_ptr(rendered_image) if output_type == OutputType.color else 0),
                       diffvg.float_ptr(pydiffvg.data_ptr(rendered_image) if output_type == OutputType.sdf else 0),
                       width,
@@ -430,10 +431,13 @@ def forward(width,
                       int(num_samples_x),
                       int(num_samples_y),
                       seed,
+                      diffvg.float_ptr(0), # d_background_image
                       diffvg.float_ptr(0), # d_render_image
                       diffvg.float_ptr(0), # d_render_sdf
                       diffvg.float_ptr(0), # d_translation
-                      use_prefiltering)
+                      use_prefiltering,
+                      diffvg.float_ptr(0), # eval_positions
+                      0 ) # num_eval_positions (automatically set to entire raster)
         time_elapsed = time.time() - start
         if print_timing:
             print('Forward pass, time: %.5f s' % time_elapsed)
@@ -487,6 +491,7 @@ def render(*x):
         start = time.time()
         with tf.device(pydiffvg.get_device_name()):
             diffvg.render(scene,
+                          diffvg.float_ptr(0), # background_image
                           diffvg.float_ptr(0), # render_image
                           diffvg.float_ptr(0), # render_sdf
                           width,
@@ -494,10 +499,13 @@ def render(*x):
                           num_samples_x,
                           num_samples_y,
                           seed,
+                          diffvg.float_ptr(0), # d_background_image
                           diffvg.float_ptr(pydiffvg.data_ptr(grad_img) if output_type == OutputType.color else 0),
                           diffvg.float_ptr(pydiffvg.data_ptr(grad_img) if output_type == OutputType.sdf else 0),
                           diffvg.float_ptr(0), # d_translation
-                          use_prefiltering)
+                          use_prefiltering,
+                          diffvg.float_ptr(0), # eval_positions
+                          0 ) # num_eval_positions (automatically set to entire raster))
         time_elapsed = time.time() - start
         global print_timing
         if print_timing:


### PR DESCRIPTION
Updated the interface in `pydiffvg_tensorflow/render_tensorflow.py` to use all the arguments to the function `render` in `diffvg.cpp`. The placeholders (arguments `background_image`, `d_background_image`, `eval_positions` and `num_eval_positions` are simply `NULL` for now—`0` (zero) in the latter case of an `int`, which defaults to evaluating over the entire raster domain), so that the default behavior results and the sample app in `apps/single_circle_tf.py` runs successfully. Fixes #7. 