### PR TITLE
Parse named colors

### DIFF
--- a/pydiffvg/parse_svg.py
+++ b/pydiffvg/parse_svg.py
@@ -10,6 +10,7 @@ import re
 import warnings
 import cssutils
 import logging
+import matplotlib.colors 
 cssutils.log.setLevel(logging.ERROR)
 
 def remove_namespaces(s):
@@ -70,7 +71,11 @@ def parse_color(s, defs):
     elif s == 'none':
         return None
     else:
-        warnings.warn('Unknown color command ' + s)
+        try : 
+            rgba = matplotlib.colors.to_rgba(s)
+            color = torch.tensor(rgba)
+        except ValueError : 
+            warnings.warn('Unknown color command ' + s)
     return color
 
 # https://github.com/mathandy/svgpathtools/blob/7ebc56a831357379ff22216bec07e2c12e8c5bc6/svgpathtools/parser.py


### PR DESCRIPTION
The svg parser will incorrectly parse colors such as 'green' and 'red' to black. This commit fixes that by using the code already written in matplotlib.colors module. For example, on an SVG like:

```
<svg width="100" height="100">
   <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
</svg> 
```

The output of the master will be a black circle:

![incorrect](https://user-images.githubusercontent.com/7254326/118116028-5d6b0e80-b407-11eb-9baf-24a8f08e3f3a.png)

With this commit, the correct image will be rendered:

![correct](https://user-images.githubusercontent.com/7254326/118116083-71167500-b407-11eb-99bd-a9207eae5116.png)

