### PR TITLE
Support optional flag to clamp gradient in 'backward' to prevent crash

### DIFF
--- a/apps/gaussian_blur.py
+++ b/apps/gaussian_blur.py
@@ -15,7 +15,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gra
                  2,   # num_samples_x
                  2,   # num_samples_y
                  0,   # seed
-                 None,
+                 None, # background_image
                  backward_clamp_gradient_mag,
                  *scene_args)
     return img

--- a/apps/gaussian_blur.py
+++ b/apps/gaussian_blur.py
@@ -6,7 +6,7 @@ import torch as th
 import scipy.ndimage.filters as F
 
 
-def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None):
+def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient_mag=None):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
         canvas_width, canvas_height, shapes, shape_groups)
@@ -16,7 +16,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gra
                  2,   # num_samples_y
                  0,   # seed
                  None,
-                 backward_clamp_gradient,
+                 backward_clamp_gradient_mag,
                  *scene_args)
     return img
 

--- a/apps/gaussian_blur.py
+++ b/apps/gaussian_blur.py
@@ -6,7 +6,7 @@ import torch as th
 import scipy.ndimage.filters as F
 
 
-def render(canvas_width, canvas_height, shapes, shape_groups):
+def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
         canvas_width, canvas_height, shapes, shape_groups)
@@ -16,6 +16,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups):
                  2,   # num_samples_y
                  0,   # seed
                  None,
+                 backward_clamp_gradient,
                  *scene_args)
     return img
 

--- a/apps/generative_models/mnist_vae.py
+++ b/apps/generative_models/mnist_vae.py
@@ -50,13 +50,14 @@ def _onehot(label):
 def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(
-        canvas_width, canvas_height, shapes, shape_groups)
+        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None)
     img = _render(canvas_width,
                   canvas_height,
                   samples,
                   samples,
                   0,
                   None,
+                  backward_clamp_gradient,
                   *scene_args)
     return img
 

--- a/apps/generative_models/mnist_vae.py
+++ b/apps/generative_models/mnist_vae.py
@@ -47,16 +47,16 @@ def _onehot(label):
     return label_onehot.float()
 
 
-def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
+def render(canvas_width, canvas_height, shapes, shape_groups, samples=2, backward_clamp_gradient_mag=None):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(
-        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient_mag=None)
+        canvas_width, canvas_height, shapes, shape_groups)
     img = _render(canvas_width,
                   canvas_height,
                   samples,
                   samples,
-                  0,
-                  None,
+                  0, # seed
+                  None, # background_image
                   backward_clamp_gradient_mag,
                   *scene_args)
     return img

--- a/apps/generative_models/mnist_vae.py
+++ b/apps/generative_models/mnist_vae.py
@@ -50,14 +50,14 @@ def _onehot(label):
 def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(
-        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None)
+        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient_mag=None)
     img = _render(canvas_width,
                   canvas_height,
                   samples,
                   samples,
                   0,
                   None,
-                  backward_clamp_gradient,
+                  backward_clamp_gradient_mag,
                   *scene_args)
     return img
 

--- a/apps/generative_models/rendering.py
+++ b/apps/generative_models/rendering.py
@@ -12,7 +12,7 @@ import time
 
 
 def render(canvas_width, canvas_height, shapes, shape_groups, samples=2,
-           seed=None, backward_clamp_gradient=None):
+           seed=None, backward_clamp_gradient_mag=None):
     if seed is None:
         seed = random.randint(0, 1000000)
     _render = pydiffvg.RenderFunction.apply
@@ -21,7 +21,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups, samples=2,
     img = _render(canvas_width, canvas_height, samples, samples,
                   seed,   # seed
                   None,  # background image
-                  backward_clamp_gradient,
+                  backward_clamp_gradient_mag,
                   *scene_args)
     return img
 

--- a/apps/generative_models/rendering.py
+++ b/apps/generative_models/rendering.py
@@ -12,7 +12,7 @@ import time
 
 
 def render(canvas_width, canvas_height, shapes, shape_groups, samples=2,
-           seed=None):
+           seed=None, backward_clamp_gradient=None):
     if seed is None:
         seed = random.randint(0, 1000000)
     _render = pydiffvg.RenderFunction.apply
@@ -21,6 +21,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups, samples=2,
     img = _render(canvas_width, canvas_height, samples, samples,
                   seed,   # seed
                   None,  # background image
+                  backward_clamp_gradient,
                   *scene_args)
     return img
 

--- a/apps/render_svg.py
+++ b/apps/render_svg.py
@@ -7,7 +7,7 @@ import pydiffvg
 import torch as th
 
 
-def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None):
+def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient_mag=None):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
         canvas_width, canvas_height, shapes, shape_groups)
@@ -17,7 +17,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gra
                  2,   # num_samples_y
                  0,   # seed
                  None,
-                 backward_clamp_gradient,
+                 backward_clamp_gradient_mag,
                  *scene_args)
     return img
 

--- a/apps/render_svg.py
+++ b/apps/render_svg.py
@@ -16,7 +16,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gra
                  2,   # num_samples_x
                  2,   # num_samples_y
                  0,   # seed
-                 None,
+                 None, # background_image
                  backward_clamp_gradient_mag,
                  *scene_args)
     return img

--- a/apps/render_svg.py
+++ b/apps/render_svg.py
@@ -7,7 +7,7 @@ import pydiffvg
 import torch as th
 
 
-def render(canvas_width, canvas_height, shapes, shape_groups):
+def render(canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
         canvas_width, canvas_height, shapes, shape_groups)
@@ -17,6 +17,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups):
                  2,   # num_samples_y
                  0,   # seed
                  None,
+                 backward_clamp_gradient,
                  *scene_args)
     return img
 

--- a/apps/seam_carving.py
+++ b/apps/seam_carving.py
@@ -109,7 +109,7 @@ def carve_seam(im):
 def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
-        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None)
+        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient_mag=None)
 
     img = _render(canvas_width, # width
                  canvas_height, # height
@@ -117,7 +117,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
                  samples,   # num_samples_y
                  0,   # seed
                  None,
-                 backward_clamp_gradient,
+                 backward_clamp_gradient_mag,
                  *scene_args)
     return img
 

--- a/apps/seam_carving.py
+++ b/apps/seam_carving.py
@@ -106,17 +106,17 @@ def carve_seam(im):
     return new_im
 
 
-def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
+def render(canvas_width, canvas_height, shapes, shape_groups, samples=2, backward_clamp_gradient_mag=None):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
-        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient_mag=None)
+        canvas_width, canvas_height, shapes, shape_groups)
 
     img = _render(canvas_width, # width
                  canvas_height, # height
                  samples,   # num_samples_x
                  samples,   # num_samples_y
                  0,   # seed
-                 None,
+                 None, # background_image
                  backward_clamp_gradient_mag,
                  *scene_args)
     return img

--- a/apps/seam_carving.py
+++ b/apps/seam_carving.py
@@ -109,7 +109,7 @@ def carve_seam(im):
 def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
-        canvas_width, canvas_height, shapes, shape_groups)
+        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None)
 
     img = _render(canvas_width, # width
                  canvas_height, # height
@@ -117,6 +117,7 @@ def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
                  samples,   # num_samples_y
                  0,   # seed
                  None,
+                 backward_clamp_gradient,
                  *scene_args)
     return img
 

--- a/apps/svg_brush.py
+++ b/apps/svg_brush.py
@@ -35,7 +35,7 @@ def checkerboard(shape, square_size=2):
     res=bin*np.array([[[1., 1., 1.,]]])+(1-bin)*np.array([[[.75, .75, .75,]]])
     return torch.tensor(res,requires_grad=False,dtype=torch.float32)
 
-def render(optim, viewport):
+def render(optim, viewport, backward_clamp_gradient=None):
     scene_args = pydiffvg.RenderFunction.serialize_scene(*optim.build_scene())
     render = pydiffvg.RenderFunction.apply
     img = render(viewport[0],  # width
@@ -44,6 +44,7 @@ def render(optim, viewport):
                  2,  # num_samples_y
                  0,  # seed
                  None,
+                 backward_clamp_gradient,
                  *scene_args)
     return img
 

--- a/apps/svg_brush.py
+++ b/apps/svg_brush.py
@@ -43,7 +43,7 @@ def render(optim, viewport, backward_clamp_gradient_mag=None):
                  2,  # num_samples_x
                  2,  # num_samples_y
                  0,  # seed
-                 None,
+                 None, # background_image
                  backward_clamp_gradient_mag,
                  *scene_args)
     return img

--- a/apps/svg_brush.py
+++ b/apps/svg_brush.py
@@ -35,7 +35,7 @@ def checkerboard(shape, square_size=2):
     res=bin*np.array([[[1., 1., 1.,]]])+(1-bin)*np.array([[[.75, .75, .75,]]])
     return torch.tensor(res,requires_grad=False,dtype=torch.float32)
 
-def render(optim, viewport, backward_clamp_gradient=None):
+def render(optim, viewport, backward_clamp_gradient_mag=None):
     scene_args = pydiffvg.RenderFunction.serialize_scene(*optim.build_scene())
     render = pydiffvg.RenderFunction.apply
     img = render(viewport[0],  # width
@@ -44,7 +44,7 @@ def render(optim, viewport, backward_clamp_gradient=None):
                  2,  # num_samples_y
                  0,  # seed
                  None,
-                 backward_clamp_gradient,
+                 backward_clamp_gradient_mag,
                  *scene_args)
     return img
 

--- a/apps/texture_synthesis.py
+++ b/apps/texture_synthesis.py
@@ -36,13 +36,14 @@ def texture_syn(img_path):
 def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
-        canvas_width, canvas_height, shapes, shape_groups)
+        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None)
     img = _render(canvas_width, # width
                  canvas_height, # height
                  samples,   # num_samples_x
                  samples,   # num_samples_y
                  0,   # seed
                  None,
+                 backward_clamp_gradient,
                  *scene_args)
     return img
 

--- a/apps/texture_synthesis.py
+++ b/apps/texture_synthesis.py
@@ -33,16 +33,16 @@ def texture_syn(img_path):
     return np.array(target_img)
 
 
-def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
+def render(canvas_width, canvas_height, shapes, shape_groups, samples=2, backward_clamp_gradient_mag=None):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
-        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient_mag=None)
+        canvas_width, canvas_height, shapes, shape_groups)
     img = _render(canvas_width, # width
                  canvas_height, # height
                  samples,   # num_samples_x
                  samples,   # num_samples_y
                  0,   # seed
-                 None,
+                 None, # background_image
                  backward_clamp_gradient_mag,
                  *scene_args)
     return img

--- a/apps/texture_synthesis.py
+++ b/apps/texture_synthesis.py
@@ -36,14 +36,14 @@ def texture_syn(img_path):
 def render(canvas_width, canvas_height, shapes, shape_groups, samples=2):
     _render = pydiffvg.RenderFunction.apply
     scene_args = pydiffvg.RenderFunction.serialize_scene(\
-        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient=None)
+        canvas_width, canvas_height, shapes, shape_groups, backward_clamp_gradient_mag=None)
     img = _render(canvas_width, # width
                  canvas_height, # height
                  samples,   # num_samples_x
                  samples,   # num_samples_y
                  0,   # seed
                  None,
-                 backward_clamp_gradient,
+                 backward_clamp_gradient_mag,
                  *scene_args)
     return img
 

--- a/pydiffvg/optimize_svg.py
+++ b/pydiffvg/optimize_svg.py
@@ -1017,7 +1017,7 @@ class OptimizableSvg:
             if issubclass(item.__class__,OptimizableSvg.SvgNode):
                 item.zero_grad()
 
-    def render(self,scale=None,seed=0):
+    def render(self,scale=None,seed=0,backward_clamp_gradient=None):
         #render at native resolution
         scene = self.build_scene()
         scene_args = pydiffvg.RenderFunction.serialize_scene(*scene)
@@ -1029,6 +1029,7 @@ class OptimizableSvg:
                      2,  # num_samples_y
                      seed,  # seed
                      None, # background_image
+                     backward_clamp_gradient,
                      *scene_args)
         return img
 

--- a/pydiffvg/optimize_svg.py
+++ b/pydiffvg/optimize_svg.py
@@ -1017,7 +1017,7 @@ class OptimizableSvg:
             if issubclass(item.__class__,OptimizableSvg.SvgNode):
                 item.zero_grad()
 
-    def render(self,scale=None,seed=0,backward_clamp_gradient=None):
+    def render(self,scale=None,seed=0,backward_clamp_gradient_mag=None):
         #render at native resolution
         scene = self.build_scene()
         scene_args = pydiffvg.RenderFunction.serialize_scene(*scene)
@@ -1029,7 +1029,7 @@ class OptimizableSvg:
                      2,  # num_samples_y
                      seed,  # seed
                      None, # background_image
-                     backward_clamp_gradient,
+                     backward_clamp_gradient_mag,
                      *scene_args)
         return img
 

--- a/pydiffvg/render_pytorch.py
+++ b/pydiffvg/render_pytorch.py
@@ -81,7 +81,7 @@ class RenderFunction(torch.autograd.Function):
                 else:
                     args.append(torch.zeros(shape.points.shape[0] - 1, dtype = torch.int32))
                 args.append(shape.points.cpu())
-                args.append(None)  
+                args.append(None)
                 args.append(shape.is_closed)
                 args.append(False) # use_distance_approx
             elif isinstance(shape, pydiffvg.Rect):
@@ -376,7 +376,7 @@ class RenderFunction(torch.autograd.Function):
             assert(eval_positions.shape[0] == 0)
             rendered_image = torch.zeros(height, width, 4, device = pydiffvg.get_device())
         else:
-            assert(output_type == OutputType.sdf)          
+            assert(output_type == OutputType.sdf)
             if eval_positions.shape[0] == 0:
                 rendered_image = torch.zeros(height, width, 1, device = pydiffvg.get_device())
             else:
@@ -459,7 +459,7 @@ class RenderFunction(torch.autograd.Function):
         use_prefiltering = args[current_index]
         current_index += 1
         eval_positions = args[current_index]
-        current_index += 1        
+        current_index += 1
         shapes = []
         shape_groups = []
         shape_contents = [] # Important to avoid GC deleting the shapes
@@ -709,11 +709,11 @@ class RenderFunction(torch.autograd.Function):
                 elif len(backward_clamp_gradient_mag) >= 2:
                     min_: -float(abs(backward_clamp_gradient_mag[0]))
                     max_: +float(abs(backward_clamp_gradient_mag[1]))
+                    if len(backward_clamp_gradient_mag) >= 3 and backward_clamp_gradient_mag[2]:
+                        print(
+                            f'Pydiffvg::backward "isfinite" assertion failed: clamping gradient to: {min_}/{max_}')
+                        )
                 backward_clamp_gradient_mag = {"min": min_, "max": max_}
-                if len(backward_clamp_gradient_mag) >= 3 and backward_clamp_gradient_mag[2]:
-                    print(
-                        f'Pydiffvg::backward "isfinite" assertion failed: clamping gradient to {backward_clamp_gradient_mag}'
-                    )
                 grad_img = torch.clamp(grad_img, **backward_clamp_gradient_mag)
 
         if background_image is not None:

--- a/pydiffvg/render_pytorch.py
+++ b/pydiffvg/render_pytorch.py
@@ -750,6 +750,7 @@ class RenderFunction(torch.autograd.Function):
         d_args.append(None) # num_samples_y
         d_args.append(None) # seed
         d_args.append(d_background_image)
+        d_args.append(None) # backward_clamp_gradient_mag
         d_args.append(None) # canvas_width
         d_args.append(None) # canvas_height
         d_args.append(None) # num_shapes


### PR DESCRIPTION
This commit addresses a very intermittent, but deadly crash bug that is destroying my training runs - a very occasional infinite gradient in the 'backward' function.

In this commit, functionality remains unchanged by default.

However, an optional flag has been added that allows clamping the gradient in the 'backward' function. The flag takes the form of an int or sequence giving the min/max value.

An optional third value in the passed sequence is interpreted as a Boolean that indicates whether to print a warning to the console whenever an infinite gradient is clamped. The default is False.

Support for PyTorch only.