### PR TITLE
Convert arc points to torch.float

### DIFF
--- a/pydiffvg/shape.py
+++ b/pydiffvg/shape.py
@@ -164,7 +164,7 @@ def from_svg_path(path_str, shape_to_canvas = torch.eye(3), force_close = False)
                     assert(e.end.imag == points[0][1])
                 else:
                     points.append((e.end.real, e.end.imag))
-        points = torch.tensor(points)
+        points = torch.tensor(points, dtype=torch.float)
         points = torch.cat((points, torch.ones([points.shape[0], 1])), dim = 1) @ torch.transpose(shape_to_canvas, 0, 1)
         points = points / points[:, 2:3]
         points = points[:, :2].contiguous()


### PR DESCRIPTION
Currently bezier points are calculated to estimate an arc and then converted to tensor via torch.Tensor. However, these points may be at float64 precision, and torch may (and indeed does) convert it to torch.Double generating errors.