### PR TITLE
Move to C++17 and fix Status call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(DIFFVG_CUDA)
     set(CMAKE_CUDA_STANDARD 11)
     if(NOT WIN32)
         # Hack: for some reason the line above doesn't work on some Linux systems.
-        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")
+        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++17")
         #set(CUDA_NVCC_FLAGS_DEBUG "-g -G")
     endif()
 else()
@@ -118,7 +118,7 @@ elseif(APPLE)
     set_target_properties(diffvg PROPERTIES INSTALL_RPATH "@loader_path")
 endif()
 
-set_property(TARGET diffvg PROPERTY CXX_STANDARD 11)
+set_property(TARGET diffvg PROPERTY CXX_STANDARD 17)
 set_target_properties(diffvg PROPERTIES PREFIX "")
 # Still enable assertion in release mode
 string( REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")

--- a/pydiffvg_tensorflow/custom_ops/CMakeLists.txt
+++ b/pydiffvg_tensorflow/custom_ops/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(diffvgTFCustomOp)

--- a/pydiffvg_tensorflow/custom_ops/data_ptr.cc
+++ b/pydiffvg_tensorflow/custom_ops/data_ptr.cc
@@ -27,7 +27,7 @@ REGISTER_OP("DataPtr")
     .Output("output: uint64")  // scalar
     .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
       c->set_output(0, {}); // scalar
-      return Status::OK();
+      return Status();
     });
 
 template <typename T>


### PR DESCRIPTION
This fixes diffvg building because:
- tensorflow refuses to build with c++11
- Status::OK() was removed and now Status() needs to be used.

With these changes diffvg builds for CPU on my system (AMD), I'm also trying to get diffvg to build with ROCm/HIP.